### PR TITLE
fix: Correct import path in Profile page

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -24,7 +24,7 @@ import {
   NotificationService,
   NotificationPreferences,
 } from "@/lib/notifications";
-import { localDbOperations } from "@/lib/local-db";
+import { localDbOperations } from "@/lib/local-storage";
 
 const Profile = () => {
   const [user, setUser] = useState<UserType | null>(null);


### PR DESCRIPTION
The Azure Static Web Apps deployment was failing because of an incorrect import path in `frontend/src/pages/Profile.tsx`. The file was trying to import from `local-db`, but the correct path is `local-storage`. This commit fixes the import path.