### PR TITLE
fix(frontend): Fix broken import to resolve build failure

### DIFF
--- a/frontend/src/lib/local-storage.ts
+++ b/frontend/src/lib/local-storage.ts
@@ -5,7 +5,7 @@ export interface UploadResult {
   error?: string;
 }
 
-import { buildUrl } from './local-db';
+import { buildUrl } from './api-client';
 
 export class LocalStorageService {
   private uploadEndpoint = buildUrl('/upload');


### PR DESCRIPTION
The build was failing during the Azure Static Web Apps deployment due to an incorrect import path in `frontend/src/lib/local-storage.ts`. The file was trying to import the `buildUrl` function from a non-existent file, `./local-db`.

This change corrects the import path to point to `frontend/src/lib/api-client.ts`, where the `buildUrl` function is actually defined.

This resolves the 'Could not resolve "./local-db"' error and should allow the build to complete successfully.