### PR TITLE
I've fixed the API routing and added a navigation fallback.

### DIFF
--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -1,13 +1,10 @@
 {
-  "routes": [
-    {
-      "route": "/api/*",
-      "rewrite": "https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api/:path*"
-    }
-  ],
   "globalHeaders": {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Headers": "*"
+  },
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/api/*"]
   }
 }
-


### PR DESCRIPTION
Your application was encountering 404 errors on API calls because the `staticwebapp.config.json` file contained a `rewrite` rule that incorrectly proxied all `/api/*` requests to an external service. This bypassed the integrated Azure Functions in the `/api` directory.

I corrected the issue by removing the faulty `routes` configuration.

Additionally, I added a `navigationFallback` rule to the configuration. This is a best practice for single-page applications (SPAs) and ensures that your client-side routes are correctly handled by rewriting them to `/index.html`, preventing 404 errors on page reloads or direct navigation. The `/api/*` routes are explicitly excluded from this fallback to ensure they are still handled by the backend.