### PR TITLE
Handle DB not ready in getUserByEmail

### DIFF
--- a/api/getUserByEmail/index.js
+++ b/api/getUserByEmail/index.js
@@ -1,7 +1,13 @@
-import { pool } from '../db.js';
+import { pool, dbReady } from '../db.js';
 import { jsonResponse } from '../shared.js';
 
 export default async function (context, req) {
+  if (!dbReady) {
+    context.log('Database failed to initialize');
+    context.res = jsonResponse(503, { message: 'Service Unavailable' });
+    return;
+  }
+
   try {
     const email = req.params?.email;
     if (!email) {


### PR DESCRIPTION
## Summary
- Return 503 Service Unavailable when database fails to initialize in getUserByEmail API
- Log diagnostic message for easier debugging

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689535490948832fbaeb09d4874977fb