### PR TITLE
refactor: use JSON helpers for analysis

### DIFF
--- a/frontend/src/lib/analyze.ts
+++ b/frontend/src/lib/analyze.ts
@@ -1,0 +1,13 @@
+const baseUrl = import.meta.env.VITE_API_BASE_URL || "";
+
+export async function analyzeText(text: string) {
+  const res = await fetch(`${baseUrl}/api/analyze`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text })
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data?.error || "Text analysis failed");
+  return data; // { sentiment, keyPhrases, ... }
+}


### PR DESCRIPTION
## Summary
- add analyzeText helper to POST text for analysis as JSON
- refactor AzureAIService to use analyzeText instead of FormData

## Testing
- `npm test`
- `npm --prefix frontend test`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f225bde0832f961b99958e4be109