### PR TITLE
Remove user ID from log submissions and require complete manual entries

### DIFF
--- a/api/logConsumption/index.js
+++ b/api/logConsumption/index.js
@@ -13,10 +13,7 @@ export default async function (context, req) {
     const b = req.body || {};
 
     // REQUIRED
-    const userId      = Number(b.userId);
     const productName = S(b.productName);
-
-    // OPTIONALS
     const brand       = S(b.brand);
     const category    = S(b.category);
     const amountSpent = N(b.amountSpent ?? b.amount);
@@ -24,23 +21,23 @@ export default async function (context, req) {
     const companions  = S(b.companions);
     const notes       = S(b.notes ?? b.note);
 
-    if (!userId || !productName) {
+    // Manual entry must have all fields except notes
+    if (!productName || !brand || !category || amountSpent == null || !currency || !companions) {
       context.res = {
         status: 400,
         headers: { "content-type": "application/json" },
-        body: { error: "userId and productName are required" }
+        body: { error: "Missing required fields" }
       };
       return;
     }
 
-    // ✅ FIXED: 8 placeholders for the 8 params, then NOW() for created_at
     const sql = `
       INSERT INTO consumption_logs
-      (user_id, product_name, brand, category, amount, currency, companions, notes, created_at)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8, NOW())
+      (product_name, brand, category, amount, currency, companions, notes, created_at)
+      VALUES ($1,$2,$3,$4,$5,$6,$7, NOW())
       RETURNING id
     `;
-    const params = [userId, productName, brand, category, amountSpent, currency, companions, notes];
+    const params = [productName, brand, category, amountSpent, currency, companions, notes];
 
     const result = await pool.query(sql, params);
 

--- a/api/logs/index.js
+++ b/api/logs/index.js
@@ -5,21 +5,14 @@ import { pool } from "../db.js";
 export default async function (context, req) {
   try {
     if (req.method === "GET") {
-      // Optional: let the app fetch recent logs
-      const userId = Number(req.query?.userId);
-      if (!userId) {
-        context.res = { status: 400, body: { error: "userId is required" } };
-        return;
-      }
+      // Fetch recent logs without requiring a user identifier
       const r = await pool.query(
         `SELECT id, product_name, brand, category, amount, currency, companions, notes, meal_details, created_at
          FROM consumption_logs
-         WHERE user_id=$1
          ORDER BY created_at DESC
-         LIMIT 50`,
-        [userId]
+         LIMIT 50`
       );
-      context.res = { status: 200, body: { ok: true, items: r.rows } };
+      context.res = { status: 200, body: r.rows };
       return;
     }
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -11,7 +11,6 @@ export interface User {
 
 export interface ConsumptionLog {
   id: string;
-  userId: string;
   product: string;
   brand?: string;
   category: string;
@@ -114,8 +113,8 @@ export const localDbOperations = {
     });
   },
 
-  async getUserConsumptionLogs(userId: string): Promise<ConsumptionLog[]> {
-    return request<ConsumptionLog[]>(`logs/user/${userId}`);
+  async getUserConsumptionLogs(): Promise<ConsumptionLog[]> {
+    return request<ConsumptionLog[]>('logs');
   },
 
   async getAllConsumptionLogs(): Promise<ConsumptionLog[]> {

--- a/frontend/src/lib/database.ts
+++ b/frontend/src/lib/database.ts
@@ -19,7 +19,6 @@ export interface User {
 
 export interface ConsumptionLog {
   id: string;
-  userId: string;
   product: string;
   brand?: string;
   category: string;
@@ -99,18 +98,17 @@ export const dbOperations = {
       .insert(logData)
       .select()
       .single();
-    
+
     if (error) throw error;
     return data;
   },
 
-  async getUserConsumptionLogs(userId: string) {
+  async getUserConsumptionLogs() {
     const { data, error } = await supabase
       .from('consumption_logs')
       .select('*')
-      .eq('userId', userId)
       .order('createdAt', { ascending: false });
-    
+
     if (error) throw error;
     return data;
   },

--- a/frontend/src/lib/manual.ts
+++ b/frontend/src/lib/manual.ts
@@ -1,6 +1,5 @@
 // /frontend/src/lib/manual.ts
 export type ManualEntryPayload = {
-  userId: number | string;
   productName: string;
   brand?: string | null;
   category?: string | null;

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -48,7 +48,7 @@ const AdminDashboard = () => {
       // Calculate stats
       const totalLogs = logs.length;
       const totalPoints = logs.reduce((sum: number, log: ConsumptionLog) => sum + (log.points || 0), 0);
-      const uniqueUsers = new Set(logs.map((log: ConsumptionLog) => log.userId)).size;
+      const uniqueUsers = new Set(logs.map((log: ConsumptionLog) => log.users?.email).filter(Boolean)).size;
       
       setStats({
         totalUsers: uniqueUsers,

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -56,9 +56,7 @@ const Dashboard = () => {
         setUser(currentUser);
 
         // Load user's consumption logs
-        const logs = await localDbOperations.getUserConsumptionLogs(
-          currentUser.id,
-        );
+        const logs = await localDbOperations.getUserConsumptionLogs();
         setRecentLogs(logs.slice(0, 3)); // Get latest 3 logs
 
         // Calculate dashboard stats from logs

--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -198,6 +198,20 @@ const LogConsumption = () => {
         return;
       }
 
+      // Ensure manual entries have all required fields (except notes)
+      if (captureMethod === 'manual') {
+        const { product, brand, category, spend, companions } = formData;
+        if (!product || !brand || !category || !spend || !companions) {
+          toast({
+            title: "Missing information",
+            description: "Please complete all fields before submitting.",
+            variant: "destructive",
+          });
+          setIsSubmitting(false);
+          return;
+        }
+      }
+
       let mediaUrl = '';
 
       // Compress and upload locally if a file was recorded
@@ -231,7 +245,6 @@ const LogConsumption = () => {
 
       // Create consumption log
       const logData = {
-        userId: currentUser.id,
         product: formData.product,
         brand: formData.brand,
         category: formData.category,

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -77,9 +77,7 @@ const Profile = () => {
       const currentUser = await authUtils.getCurrentUser();
       if (currentUser) {
         // Load user's consumption logs to calculate stats
-        const logs = await dbOperations.getUserConsumptionLogs(
-          currentUser.id,
-        );
+        const logs = await dbOperations.getUserConsumptionLogs();
 
         // Calculate streak
         const streak = calculateStreak(logs);

--- a/frontend/src/pages/Rewards.tsx
+++ b/frontend/src/pages/Rewards.tsx
@@ -40,9 +40,7 @@ const Rewards = () => {
         setUser(currentUser);
         setUserPoints(currentUser.points || 0);
 
-        const logs = await localDbOperations.getUserConsumptionLogs(
-          currentUser.id,
-        );
+        const logs = await localDbOperations.getUserConsumptionLogs();
         setAchievements(calculateAchievements(logs, currentUser));
       }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -13,7 +13,6 @@ export interface User {
 
 export interface ConsumptionLog {
   id: string;
-  userId: string;
   product: string;
   brand?: string;
   category: string;
@@ -85,7 +84,6 @@ export interface RegisterRequest {
 }
 
 export interface CreateConsumptionLogRequest {
-  userId: string;
   product: string;
   brand?: string;
   category: string;


### PR DESCRIPTION
## Summary
- stop storing `userId` in consumption logs and API payloads
- enforce that manual entries fill all fields except notes
- allow retrieving logs without a user identifier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c5b6542b4832fb0241654cb82e006