### PR TITLE
Accept `product` field for consumption logs

### DIFF
--- a/api/lib/saveLog.js
+++ b/api/lib/saveLog.js
@@ -24,7 +24,7 @@ export async function saveLog(body, context) {
 
   // product name from several possible fields
   const productName =
-    S(pick(b, "productName", "product_name", "name")) ||
+    S(pick(b, "productName", "product_name", "name", "product")) ||
     S(pick(b, "snack", "item")) ||
     (Array.isArray(b.snacks) && S(b.snacks[0])) ||
     (Array.isArray(analysis.snacks) && S(analysis.snacks[0])) ||

--- a/api/logConsumption/index.js
+++ b/api/logConsumption/index.js
@@ -13,7 +13,7 @@ export default async function (context, req) {
     const b = req.body || {};
 
     // REQUIRED
-    const productName = S(b.productName);
+    const productName = S(b.productName ?? b.product ?? b.name);
     const brand       = S(b.brand);
     const category    = S(b.category);
     const amountSpent = N(b.amountSpent ?? b.amount);

--- a/api/logs/index.js
+++ b/api/logs/index.js
@@ -7,7 +7,7 @@ export default async function (context, req) {
     if (req.method === "GET") {
       // Fetch recent logs without requiring a user identifier
       const r = await pool.query(
-        `SELECT id, product_name, brand, category, amount, currency, companions, notes, meal_details, created_at
+        `SELECT id, product_name AS product, brand, category, amount, currency, companions, notes, meal_details, created_at
          FROM consumption_logs
          ORDER BY created_at DESC
          LIMIT 50`


### PR DESCRIPTION
## Summary
- allow `product` as a valid alias for product name when saving logs
- support `product` in manual log endpoint
- return `product` instead of `product_name` in recent log queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c65fb0d80832f924a93c7a3601b60