### PR TITLE
fix: remove meal_details references from logs API

### DIFF
--- a/api/lib/saveLog.js
+++ b/api/lib/saveLog.js
@@ -15,7 +15,7 @@ const pick = (obj, ...keys) => {
 
 /**
  * Accepts payloads from:
- * - your manual form (mealDetails, productName, brand, category, amountSpent, companions, notes)
+ * - your manual form (productName, brand, category, amountSpent, companions, notes)
  * - AI capture (may send snack/snacks, mood, amount, transcript/text/whatYouSaid, etc.)
  */
 export async function saveLog(body, context) {
@@ -31,7 +31,6 @@ export async function saveLog(body, context) {
     S(analysis.snack) ||
     null;
 
-  const mealDetails = S(pick(b, "mealDetails", "meal_details"));
   const brand       = S(pick(b, "brand", "brandName"));
   const category    = S(pick(b, "category", "categoryName"));
 
@@ -56,11 +55,11 @@ export async function saveLog(body, context) {
   // If your table has no mood column, drop mood in the INSERT & params.
   const sql = `
     INSERT INTO consumption_logs
-      (meal_details, product_name, brand, category, amount, currency, companions, notes, created_at)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8, NOW())
+      (product_name, brand, category, amount, currency, companions, notes, created_at)
+    VALUES ($1,$2,$3,$4,$5,$6,$7, NOW())
     RETURNING id
   `;
-  const params = [mealDetails, productName, brand, category, amountSpent, currency, companions, notes];
+  const params = [productName, brand, category, amountSpent, currency, companions, notes];
 
   const result = await pool.query(sql, params);
   return Number(result.rows[0].id);

--- a/api/logs/index.js
+++ b/api/logs/index.js
@@ -7,7 +7,7 @@ export default async function (context, req) {
     if (req.method === "GET") {
       // Fetch recent logs without requiring a user identifier
       const r = await pool.query(
-        `SELECT id, product_name AS product, brand, category, amount, currency, companions, notes, meal_details, created_at
+        `SELECT id, product_name AS product, brand, category, amount, currency, companions, notes, created_at
          FROM consumption_logs
          ORDER BY created_at DESC
          LIMIT 50`


### PR DESCRIPTION
## Summary
- drop meal_details usage in saveLog insert
- stop selecting meal_details in logs listing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6985ce38832f92896266e38a3aee