### PR TITLE
feat: show Nigerian food analysis

### DIFF
--- a/api/analyze/index.js
+++ b/api/analyze/index.js
@@ -66,27 +66,30 @@ export default async function (context, req) {
       }
     }
 
-    // Snacks detection
-    const SNACKS = new Set([
-      "chips","plantain chips","crisps","biscuit","biscuits","cookie","cookies",
-      "cake","cupcake","chocolate","candy","sweet","sweets","popcorn","nuts","peanuts",
-      "granola bar","energy bar","yogurt","yoghurt","ice cream","meat pie","sausage roll",
-      "gala","puff puff","chin chin","meatpie","pie","donut","doughnut","shawarma","buns"
+    // Nigerian foods detection
+    const NIGERIAN_FOODS = new Set([
+      "jollof rice","suya","pounded yam","egusi","pepper soup","chin chin",
+      "plantain","akara","moi moi","fufu","garri","puff puff","meat pie",
+      "meatpie","gala","buns","shawarma","chips","plantain chips","crisps",
+      "biscuit","biscuits","cookie","cookies","cake","cupcake","chocolate",
+      "candy","sweet","sweets","popcorn","nuts","peanuts","granola bar",
+      "energy bar","yogurt","yoghurt","ice cream","sausage roll","pie",
+      "donut","doughnut"
     ]);
     function norm(s) { return s.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, "").trim(); }
     const candidates = new Set();
     for (const kp of (phrases?.keyPhrases || [])) {
       const k = norm(kp);
-      if (SNACKS.has(k)) candidates.add(k);
-      for (const t of k.split(/\s+/)) if (SNACKS.has(t)) candidates.add(t);
+      if (NIGERIAN_FOODS.has(k)) candidates.add(k);
+      for (const t of k.split(/\s+/)) if (NIGERIAN_FOODS.has(t)) candidates.add(t);
     }
     for (const t of norm(text).split(/\s+/)) {
       if (!t) continue;
       const s = t.endsWith("s") ? t.slice(0, -1) : t;
-      if (SNACKS.has(t)) candidates.add(t);
-      if (SNACKS.has(s)) candidates.add(s);
+      if (NIGERIAN_FOODS.has(t)) candidates.add(t);
+      if (NIGERIAN_FOODS.has(s)) candidates.add(s);
     }
-    const snacks = Array.from(candidates).sort();
+    const nigerianFoods = Array.from(candidates).sort();
 
     context.res = jsonResponse(200, {
       // original fields kept
@@ -100,7 +103,7 @@ export default async function (context, req) {
       // tidy summary for your UI
       mood: label,
       confidence,
-      snacks,
+      nigerianFoods,
       amountSpent,
       said: text
     });

--- a/api/lib/saveLog.js
+++ b/api/lib/saveLog.js
@@ -17,7 +17,7 @@ const pick = (obj, ...keys) => {
 /**
  * Accepts payloads from:
  * - your manual form (productName, brand, category, amountSpent, companions, notes)
- * - AI capture (may send snack/snacks, mood, amount, transcript/text/whatYouSaid, etc.)
+ * - AI capture (may send nigerianFood/nigerianFoods, mood, amount, transcript/text/whatYouSaid, etc.)
  */
 export async function saveLog(body, context) {
   const b = body || {};
@@ -28,9 +28,12 @@ export async function saveLog(body, context) {
   // primary product fields
   const product =
     S(pick(b, "product", "productName", "product_name", "name")) ||
-    S(pick(b, "snack", "item")) ||
+    S(pick(b, "snack", "item", "food")) ||
+    (Array.isArray(b.nigerianFoods) && S(b.nigerianFoods[0])) ||
+    (Array.isArray(analysis.nigerianFoods) && S(analysis.nigerianFoods[0])) ||
     (Array.isArray(b.snacks) && S(b.snacks[0])) ||
     (Array.isArray(analysis.snacks) && S(analysis.snacks[0])) ||
+    S(analysis.nigerianFood) ||
     S(analysis.snack) ||
     null;
 

--- a/frontend/src/lib/azure-ai.ts
+++ b/frontend/src/lib/azure-ai.ts
@@ -2,7 +2,7 @@
 export type AzureAIAnalysis = {
   mood: string;
   confidence: number | null;
-  snacks: string[];
+  nigerianFoods: string[];
   amountSpent: { currency: string; amount: number; text: string } | null;
   said: string;
   // keep originals (optional)

--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -240,7 +240,7 @@ const LogConsumption = () => {
       // Auto-fill form with AI analysis (no manual corrections)
       setFormData({
         ...initialFormState,
-        product: analysis.snacks?.[0] || 'Unknown snack',
+        product: analysis.nigerianFoods?.[0] || 'Unknown food',
         brand: 'Unknown',
         category: 'Other',
         companions: 'Unknown',
@@ -517,30 +517,26 @@ const LogConsumption = () => {
                       <div className="glass-effect rounded-lg p-4">
                         <h4 className="font-semibold text-primary mb-3">AI Analysis Results</h4>
                         <div className="grid grid-cols-2 gap-3 text-sm">
-                          {aiAnalysis.snacks && aiAnalysis.snacks.length > 0 && (
-                            <div>
-                              <span className="text-primary font-medium">Snacks:</span>
-                              <span className="ml-2 text-foreground">{aiAnalysis.snacks.join(', ')}</span>
-                            </div>
-                          )}
-                          {aiAnalysis.confidence !== null && (
-                            <div>
-                              <span className="text-primary font-medium">Confidence:</span>
-                              <span className="ml-2 text-foreground">{Math.round(aiAnalysis.confidence * 100)}%</span>
-                            </div>
-                          )}
-                          {aiAnalysis.mood && (
-                            <div>
-                              <span className="text-primary font-medium">Mood:</span>
-                              <span className="ml-2 text-foreground">{aiAnalysis.mood}</span>
-                            </div>
-                          )}
-                          {aiAnalysis.amountSpent && (
-                            <div>
-                              <span className="text-primary font-medium">Est. Spend:</span>
-                              <span className="ml-2 text-foreground">{aiAnalysis.amountSpent.currency === 'NGN' ? '₦' : aiAnalysis.amountSpent.currency} {aiAnalysis.amountSpent.amount}</span>
-                            </div>
-                          )}
+                          <div>
+                            <span className="text-primary font-medium">Nigerian Foods:</span>
+                            <span className="ml-2 text-foreground">{aiAnalysis.nigerianFoods?.join(', ') || ''}</span>
+                          </div>
+                          <div>
+                            <span className="text-primary font-medium">Confidence:</span>
+                            <span className="ml-2 text-foreground">{aiAnalysis.confidence != null ? `${Math.round(aiAnalysis.confidence * 100)}%` : ''}</span>
+                          </div>
+                          <div>
+                            <span className="text-primary font-medium">Mood:</span>
+                            <span className="ml-2 text-foreground">{aiAnalysis.mood || ''}</span>
+                          </div>
+                          <div>
+                            <span className="text-primary font-medium">Amount Spent:</span>
+                            <span className="ml-2 text-foreground">
+                              {aiAnalysis.amountSpent
+                                ? `${aiAnalysis.amountSpent.currency === 'NGN' ? '₦' : aiAnalysis.amountSpent.currency} ${aiAnalysis.amountSpent.amount}`
+                                : ''}
+                            </span>
+                          </div>
                         </div>
                         {aiAnalysis.said && (
                           <div className="mt-3">


### PR DESCRIPTION
## Summary
- detect common Nigerian foods in analysis results
- always display Nigerian Foods, Confidence, Mood and Amount Spent in UI
- save logs using Nigerian food info when available

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c94d159b8832f8c18f3f0205a5c61