### PR TITLE
Handle missing transcription before AI analysis

### DIFF
--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -224,6 +224,14 @@ const LogConsumption = () => {
       if (file.type.includes('audio') || file.type.includes('video')) {
         transcription = await transcribeAudio(file);
         setAnalysisProgress(50);
+        if (!transcription.trim()) {
+          toast({
+            title: "Transcription failed",
+            description: "No speech detected in the recording.",
+            variant: "destructive",
+          });
+          return;
+        }
       }
 
       // Analyze consumption data


### PR DESCRIPTION
## Summary
- avoid calling Azure analysis when transcription has no content
- notify user when no speech is detected in recording

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9896b18c832fbf21f3ff3c25bd96