### PR TITLE
Use real snack categories and remove placeholders

### DIFF
--- a/api/getCategories/function.json
+++ b/api/getCategories/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "categories"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/api/getCategories/index.js
+++ b/api/getCategories/index.js
@@ -1,0 +1,15 @@
+import { pool } from '../db.js';
+import { jsonResponse } from '../shared.js';
+
+export default async function (context, req) {
+  try {
+    const { rows } = await pool.query(
+      "SELECT DISTINCT category FROM consumption_logs WHERE category IS NOT NULL AND category <> '' ORDER BY category"
+    );
+    const categories = rows.map(r => r.category);
+    context.res = jsonResponse(200, categories);
+  } catch (err) {
+    context.log.error('categories error:', err);
+    context.res = jsonResponse(err.statusCode || 500, { error: err.message || 'Failed to fetch categories' });
+  }
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -125,6 +125,10 @@ export const localDbOperations = {
     return request('analytics/logs');
   },
 
+  async getCategories(): Promise<string[]> {
+    return request<string[]>('categories');
+  },
+
   async getRewards(): Promise<Reward[]> {
     return request('rewards');
   },

--- a/frontend/src/lib/database.ts
+++ b/frontend/src/lib/database.ts
@@ -136,9 +136,22 @@ export const dbOperations = {
       .from('consumption_logs')
       .select('category, createdAt, points')
       .order('createdAt', { ascending: false });
-    
+
     if (error) throw error;
     return data;
+  },
+
+  async getCategories() {
+    const { data, error } = await supabase
+      .from('consumption_logs')
+      .select('category')
+      .not('category', 'is', null)
+      .neq('category', '')
+      .order('category', { ascending: true });
+
+    if (error) throw error;
+    const categories = [...new Set(data.map((d) => d.category))];
+    return categories;
   },
 
   // Rewards

--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -43,9 +43,23 @@ const LogConsumption = () => {
   const [recordingType, setRecordingType] = useState<'audio' | 'video'>('audio');
   const [captureMethod, setCaptureMethod] = useState<'manual' | 'ai'>('ai');
   const [currentLocation, setCurrentLocation] = useState<LocationData | null>(null);
-
-  const categories = ["Jollof Rice", "Suya", "Pounded Yam", "Egusi", "Pepper Soup", "Chin Chin", "Plantain", "Akara", "Moi Moi", "Other"];
+  const [categories, setCategories] = useState<string[]>([]);
   const companionOptions = ["Alone", "With friends", "With family", "With colleagues", "With partner"];
+
+  useEffect(() => {
+    async function loadCategories() {
+      try {
+        const list = await dbOperations.getCategories();
+        setCategories(list);
+        if (list.length > 0) {
+          setFormData((prev) => ({ ...prev, category: prev.category || list[0] }));
+        }
+      } catch (err) {
+        console.error('Error loading categories:', err);
+      }
+    }
+    loadCategories();
+  }, []);
 
   const renderMealFields = () => (
     <>
@@ -74,7 +88,7 @@ const LogConsumption = () => {
           onValueChange={(value) => setFormData({ ...formData, category: value })}
         >
           <SelectTrigger id="category" className="glass-effect">
-            <SelectValue placeholder="Select a category" />
+            <SelectValue />
           </SelectTrigger>
           <SelectContent>
             {categories.map((cat) => (

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   User,
   Mail,
@@ -247,12 +247,9 @@ const Profile = () => {
                 <CardContent className="p-6 text-center">
                   <div className="relative inline-block mb-4">
                     <Avatar className="w-24 h-24">
-                      <AvatarImage
-                        src="/placeholder.svg"
-                        alt="User profile photo"
-                      />
                       <AvatarFallback className="gradient-primary text-white text-2xl">
-                        AO
+                        {user?.firstName?.[0]}
+                        {user?.lastName?.[0]}
                       </AvatarFallback>
                     </Avatar>
                     <button className="absolute bottom-0 right-0 w-8 h-8 gradient-primary rounded-full flex items-center justify-center text-white hover-glow">


### PR DESCRIPTION
## Summary
- add categories API endpoint to return distinct snack categories
- fetch categories from API in LogConsumption form and remove placeholder items
- drop placeholder profile image

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f3d0e719c832f816742880f02d88c