### PR TITLE
Speed up dashboard loading and audio transcription

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -41,8 +41,6 @@ const Login = () => {
     setIsLoading(true);
 
     try {
-      setIsLoading(true);
-
       const user = await localDbOperations.getUserByEmail(formData.email);
       if (
         user &&


### PR DESCRIPTION
## Summary
- Parallelize dashboard data fetching and compute rank locally
- Clean up login spinner management
- Chunk audio and transcribe in parallel for faster long-form recognition

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f428ad968832f84ef07fa09e5c244