### PR TITLE
feat: refine manual logging and responsive navigation

### DIFF
--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -14,7 +14,7 @@ const Index = () => {
             <div className="w-8 h-8 nigeria-accent rounded-full"></div>
             <h1 className="text-2xl font-bold text-gradient">SnacksTrack</h1>
           </div>
-          <div className="flex space-x-3">
+          <div className="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-3">
             <Link to="/login">
               <Button variant="outline" className="border-blue-300 text-blue-600 hover:bg-blue-50 glass-effect">
                 Login


### PR DESCRIPTION
## Summary
- Enable manual image capture with limited categories and brand dropdowns for Nigerian noodles and snacks
- Improve audio recording with explicit mime types and reset transcript
- Make landing page login and signup buttons responsive on mobile

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a282dafa04832f8e59b37ac9e6c440