### PR TITLE
Allow local network hosts for media access

### DIFF
--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -235,11 +235,22 @@ const LogConsumption = () => {
       return;
     }
 
-    const isSecure = window.isSecureContext || location.hostname === 'localhost';
+    // Browsers only allow camera/mic access from secure contexts (HTTPS or localhost).
+    // Some development setups use other loopback or private addresses, so we
+    // explicitly allow typical local network hostnames.
+    const hostname = window.location.hostname;
+    const isLocalhost =
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      /^192\.168\./.test(hostname) ||
+      /^10\./.test(hostname) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(hostname);
+    const isSecure = window.isSecureContext || isLocalhost;
     if (!isSecure) {
       toast({
         title: 'Secure context required',
-        description: 'Camera and microphone access requires HTTPS or localhost.',
+        description: 'Camera and microphone access requires HTTPS or a local host.',
         variant: 'destructive',
       });
       return;


### PR DESCRIPTION
## Summary
- Accept private IPv4 and IPv6 loopback addresses as secure contexts for camera/mic usage
- Document broader hostname handling for recording start

## Testing
- `npm test`
- `npm --prefix frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a307647050832fa086546dc40625d0