### PR TITLE
Handle missing Azure speech credentials gracefully

### DIFF
--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -270,11 +270,17 @@ const LogConsumption = () => {
 
       setLiveTranscript('');
       if (captureMethod === 'ai') {
-        speechRef.current = createSpeechRecognizer((t) => setLiveTranscript(t));
         try {
+          speechRef.current = createSpeechRecognizer((t) => setLiveTranscript(t));
           await speechRef.current.start();
         } catch (err) {
           console.error('Speech recognition error', err);
+          toast({
+            title: 'Speech recognition unavailable',
+            description:
+              'Azure speech credentials are missing or invalid. Recording will continue without live transcription.',
+            variant: 'destructive',
+          });
         }
       }
 


### PR DESCRIPTION
## Summary
- prevent recording failures when Azure speech credentials are missing
- show user-facing toast and continue without transcription

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a3121a2e08832fb0cf896c949c34cf