### PR TITLE
Use MP3 for recordings and hide live transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ On the log consumption page you can switch between **Manual Entry** and **AI Cap
 
 The recorded audio is sent to the backend `/api/transcribe` endpoint, which uses **Azure Speech Services** for transcription instead of the previous Hugging Face Whisper integration. The `/api/analyze` endpoint relies on **Azure AI Text Analytics**—not the local `natural` package—to determine sentiment and key phrases from the transcription.
 
-Audio recordings are saved as `.wav` for maximum compatibility.
+Audio recordings are saved as `.mp3` for maximum compatibility.
 
 Without valid Azure credentials these endpoints return `500` errors, so the AI Capture feature cannot be tested locally.
 

--- a/frontend/src/lib/audio-utils.ts
+++ b/frontend/src/lib/audio-utils.ts
@@ -1,108 +1,46 @@
-export class WavAudioHelper {
-  public static async convertToWav(blob: Blob): Promise<Blob> {
-    const targetSampleRate = 16000;
-    const audioContext = new AudioContext({ sampleRate: targetSampleRate });
-    const arrayBuffer = await blob.arrayBuffer();
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { fetchFile, toBlobURL } from "@ffmpeg/util";
 
-    // The following line can throw an error if the audio format is not supported.
-    // By wrapping it in a try-catch, we can provide a better error message.
-    let audioBuffer: AudioBuffer;
-    try {
-      audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-    } catch (error) {
-      console.error("Failed to decode audio data:", error);
-      // Attempt to re-wrap the blob to fix potential container issues
-      try {
-        const reWrappedBlob = new Blob([blob], { type: blob.type });
-        const reWrappedArrayBuffer = await reWrappedBlob.arrayBuffer();
-        audioBuffer = await audioContext.decodeAudioData(reWrappedArrayBuffer);
-      } catch (finalError) {
-        console.error("Failed to decode audio data after re-wrapping:", finalError);
-        throw new Error("Unsupported audio format or corrupt file.");
-      }
-    }
+let ffmpeg: FFmpeg | null = null;
 
-
-    const resampledBuffer = await this.downsampleBuffer(audioBuffer, targetSampleRate, audioContext);
-    const wavBuffer = this.audioBufferToWav(resampledBuffer, targetSampleRate);
-    await audioContext.close();
-    return new Blob([wavBuffer], { type: "audio/wav" });
-  }
-
-  private static downsampleBuffer(
-    buffer: AudioBuffer,
-    targetRate: number,
-    audioContext: BaseAudioContext
-  ): Promise<AudioBuffer> {
-    // We don't need to downsample if the sample rate is already correct
-    if (buffer.sampleRate === targetRate) {
-      return Promise.resolve(buffer);
-    }
-
-    const offlineCtx = new OfflineAudioContext({
-      numberOfChannels: buffer.numberOfChannels,
-      length: Math.ceil((buffer.duration * targetRate) / buffer.sampleRate),
-      sampleRate: targetRate,
+async function getFFmpeg() {
+  if (!ffmpeg) {
+    ffmpeg = new FFmpeg();
+    ffmpeg.on("log", ({ message }) => {
+      // console.log(message); // Uncomment for debugging
     });
 
-    const source = offlineCtx.createBufferSource();
-    source.buffer = buffer;
-    source.connect(offlineCtx.destination);
-    source.start(0);
-
-    return offlineCtx.startRendering();
+    const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
+    await ffmpeg.load({
+      coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+    });
   }
+  return ffmpeg;
+}
 
-  private static audioBufferToWav(buffer: AudioBuffer, sampleRate: number): ArrayBuffer {
-    const numOfChan = buffer.numberOfChannels;
-    const numFrames = buffer.length;
-    const bufferLength = 44 + numFrames * numOfChan * 2;
-    const arrayBuffer = new ArrayBuffer(bufferLength);
-    const view = new DataView(arrayBuffer);
+export class Mp3AudioHelper {
+  public static async convertToMp3(blob: Blob): Promise<Blob> {
+    const ffmpegInstance = await getFFmpeg();
+    const inputFileName = "input.webm";
+    const outputFileName = "output.mp3";
 
-    let offset = 0;
-    const writeString = (s: string) => {
-      for (let i = 0; i < s.length; i++) {
-        view.setUint8(offset++, s.charCodeAt(i));
-      }
-    };
-    const writeUint32 = (d: number) => {
-      view.setUint32(offset, d, true);
-      offset += 4;
-    };
-    const writeUint16 = (d: number) => {
-      view.setUint16(offset, d, true);
-      offset += 2;
-    };
+    await ffmpegInstance.writeFile(inputFileName, await fetchFile(blob));
 
-    writeString("RIFF");
-    writeUint32(36 + numFrames * numOfChan * 2);
-    writeString("WAVE");
-    writeString("fmt ");
-    writeUint32(16);
-    writeUint16(1); // PCM
-    writeUint16(numOfChan);
-    writeUint32(sampleRate);
-    writeUint32(sampleRate * numOfChan * 2);
-    writeUint16(numOfChan * 2);
-    writeUint16(16); // 16-bit
-    writeString("data");
-    writeUint32(numFrames * numOfChan * 2);
+    await ffmpegInstance.exec([
+      "-i",
+      inputFileName,
+      "-ar",
+      "16000",
+      "-ac",
+      "1",
+      "-b:a",
+      "128k",
+      outputFileName,
+    ]);
 
-    const channels: Float32Array[] = [];
-    for (let i = 0; i < numOfChan; i++) {
-      channels.push(buffer.getChannelData(i));
-    }
-
-    for (let i = 0; i < numFrames; i++) {
-      for (let channel = 0; channel < numOfChan; channel++) {
-        const sample = channels[channel][i];
-        const clamped = Math.max(-1, Math.min(1, sample));
-        view.setInt16(offset, clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff, true);
-        offset += 2;
-      }
-    }
-
-    return arrayBuffer;
+    const data = await ffmpegInstance.readFile(outputFileName);
+    return new Blob([data], { type: "audio/mpeg" });
   }
 }
+

--- a/frontend/src/lib/video-utils.ts
+++ b/frontend/src/lib/video-utils.ts
@@ -22,7 +22,7 @@ async function getFFmpeg() {
 export async function extractAudioFromVideo(videoBlob: Blob): Promise<Blob> {
   const ffmpegInstance = await getFFmpeg();
   const inputFileName = "input.webm";
-  const outputFileName = "output.opus";
+  const outputFileName = "output.mp3";
 
   await ffmpegInstance.writeFile(inputFileName, await fetchFile(videoBlob));
 
@@ -31,10 +31,16 @@ export async function extractAudioFromVideo(videoBlob: Blob): Promise<Blob> {
     inputFileName,
     "-vn", // No video
     "-acodec",
-    "copy", // Copy audio codec without re-encoding
+    "libmp3lame",
+    "-ar",
+    "16000",
+    "-ac",
+    "1",
+    "-b:a",
+    "128k",
     outputFileName,
   ]);
 
   const data = await ffmpegInstance.readFile(outputFileName);
-  return new Blob([data], { type: "audio/opus" });
+  return new Blob([data], { type: "audio/mpeg" });
 }

--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -19,7 +19,7 @@ import { getLocalStorage } from "@/lib/local-storage";
 import { getAzureStorage } from "@/lib/azure-storage";
 import { MediaCompressor } from "@/lib/media-compression";
 import { LocationService, LocationData } from "@/lib/location";
-import { WavAudioHelper } from "@/lib/audio-utils";
+import { Mp3AudioHelper } from "@/lib/audio-utils";
 import { extractAudioFromVideo } from "@/lib/video-utils";
 import { createSpeechRecognizer } from "@/lib/azure-speech";
 
@@ -314,14 +314,13 @@ const LogConsumption = () => {
           try {
             toast({ title: "Extracting audio from video..." });
             const audioBlob = await extractAudioFromVideo(blob);
-            const wavBlob = await WavAudioHelper.convertToWav(audioBlob);
             fileToAnalyze = new File(
-              [wavBlob],
-              `${userId || "anonymous"}_${timestamp}.wav`,
-              { type: "audio/wav" }
+              [audioBlob],
+              `${userId || "anonymous"}_${timestamp}.mp3`,
+              { type: "audio/mpeg" }
             );
           } catch (error) {
-            console.error("Failed to extract or convert audio from video:", error);
+            console.error("Failed to extract audio from video:", error);
             toast({
               title: "Audio Extraction Failed",
               description: "Could not process the audio from the video. Please try again.",
@@ -333,16 +332,16 @@ const LogConsumption = () => {
         } else {
           // For audio-only recordings
           try {
-            const wavBlob = await WavAudioHelper.convertToWav(blob);
+            const mp3Blob = await Mp3AudioHelper.convertToMp3(blob);
             const audioFile = new File(
-              [wavBlob],
-              `${userId || "anonymous"}_${timestamp}.wav`,
-              { type: "audio/wav" }
+              [mp3Blob],
+              `${userId || "anonymous"}_${timestamp}.mp3`,
+              { type: "audio/mpeg" }
             );
             setSelectedFile(audioFile); // This is for upload
             fileToAnalyze = audioFile;
           } catch (error) {
-            console.error("Failed to convert audio to WAV:", error);
+            console.error("Failed to convert audio to MP3:", error);
             toast({
               title: "Audio Processing Failed",
               description: "Could not process the recorded audio. Please try again.",
@@ -431,7 +430,7 @@ const LogConsumption = () => {
         spend: analysis.amountSpent
           ? `${analysis.amountSpent.currency === 'NGN' ? '₦' : analysis.amountSpent.currency} ${analysis.amountSpent.amount}`
           : '',
-        notes: analysis.said || ''
+        notes: transcription
       });
 
       toast({
@@ -678,11 +677,6 @@ const LogConsumption = () => {
                         </Button>
                       )}
                     </div>
-                    {liveTranscript && (
-                      <div className="mt-4 p-3 bg-muted rounded text-left">
-                        <p className="text-sm text-muted-foreground">{liveTranscript}</p>
-                      </div>
-                    )}
                   </div>
                 ) : (
                   <div className="space-y-4">
@@ -721,11 +715,6 @@ const LogConsumption = () => {
                         ) : (
                           <audio src={previewUrl} controls className="w-full" />
                         )}
-                      </div>
-                    )}
-                    {liveTranscript && (
-                      <div className="mt-4 p-3 bg-muted rounded text-left">
-                        <p className="text-sm text-muted-foreground">{liveTranscript}</p>
                       </div>
                     )}
 


### PR DESCRIPTION
## Summary
- encode extracted audio as MP3 via ffmpeg
- save recordings in MP3 and remove live transcript display
- document MP3 recording format

## Testing
- `npm test`
- `npm --prefix frontend test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31d59d850832f99eaf2918bd88f60