### PR TITLE
Support Azure speech env vars and fix manual log validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ AZURE_AUDIO_CONTAINER=audio-logs
 AZURE_MEDIA_CONTAINER=media-logs
 AZURE_SPEECH_KEY=<your speech key>
 AZURE_SPEECH_REGION=<your speech region>
+# These variables are also exposed to the frontend. Using
+# VITE_AZURE_SPEECH_KEY and VITE_AZURE_SPEECH_REGION works as well.
 AZURE_LANGUAGE_KEY=<your language key>
 AZURE_LANGUAGE_ENDPOINT=<your language endpoint>
 ```

--- a/frontend/src/lib/azure-speech.ts
+++ b/frontend/src/lib/azure-speech.ts
@@ -1,8 +1,12 @@
 import * as sdk from "microsoft-cognitiveservices-speech-sdk";
 
 export function createSpeechRecognizer(onText: (text: string) => void) {
-  const key = import.meta.env.VITE_AZURE_SPEECH_KEY;
-  const region = import.meta.env.VITE_AZURE_SPEECH_REGION;
+  const key =
+    import.meta.env.VITE_AZURE_SPEECH_KEY ||
+    import.meta.env.AZURE_SPEECH_KEY;
+  const region =
+    import.meta.env.VITE_AZURE_SPEECH_REGION ||
+    import.meta.env.AZURE_SPEECH_REGION;
   if (!key || !region) throw new Error("Missing Azure speech credentials");
   const speechConfig = sdk.SpeechConfig.fromSubscription(key, region);
   speechConfig.speechRecognitionLanguage = "en-US";

--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -468,8 +468,8 @@ const LogConsumption = () => {
 
       // Validate required fields per capture method
       if (captureMethod === 'manual') {
-        const { product, brand, category, spend, companions } = formData;
-        if (!product || !brand || !category || !spend || !companions) {
+        const { brand, category, spend, companions } = formData;
+        if (!brand || !category || !spend || !companions) {
           toast({
             title: "Missing information",
             description: "Please complete all fields before submitting.",
@@ -529,7 +529,7 @@ const LogConsumption = () => {
 
       // Create consumption log
       const logData = {
-        product: captureMethod === 'ai' ? formData.product : undefined,
+        product: captureMethod === 'ai' ? formData.product : formData.brand,
         brand: formData.brand,
         category: formData.category,
         spend: formData.spend ? parseFloat(formData.spend.replace('₦', '')) : undefined,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'), // allows you to use '@/components/...' etc.
     },
   },
+  envPrefix: ['VITE_', 'AZURE_'],
   build: {
     outDir: 'dist',
   },


### PR DESCRIPTION
## Summary
- allow Speech SDK to read AZURE_* or VITE_AZURE_* credentials
- expose AZURE_* env vars to the frontend build
- fix manual logging validation and send brand as product
- document Azure speech variable support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32f8e4878832f8f6a961ee4ef5125