### PR TITLE
Handle missing Azure speech credentials

### DIFF
--- a/frontend/src/pages/LogConsumption.tsx
+++ b/frontend/src/pages/LogConsumption.tsx
@@ -85,7 +85,7 @@ const LogConsumption = () => {
   const [brands, setBrands] = useState<string[]>(BRAND_OPTIONS[CATEGORY_OPTIONS[0]]);
   const companionOptions = ["Alone", "With friends", "With family", "With colleagues", "With partner"];
   const [liveTranscript, setLiveTranscript] = useState("");
-  const speechRef = useRef<ReturnType<typeof createSpeechRecognizer> | null>(null);
+  const speechRef = useRef<ReturnType<typeof createSpeechRecognizer>>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -263,11 +263,21 @@ const LogConsumption = () => {
 
       setLiveTranscript('');
       if (captureMethod === 'ai') {
-        try {
-          speechRef.current = createSpeechRecognizer((t) => setLiveTranscript(t));
-          await speechRef.current.start();
-        } catch (err) {
-          console.error('Speech recognition error', err);
+        speechRef.current = createSpeechRecognizer((t) => setLiveTranscript(t));
+        if (speechRef.current) {
+          try {
+            await speechRef.current.start();
+          } catch (err) {
+            console.error('Speech recognition error', err);
+            speechRef.current = null;
+            toast({
+              title: 'Speech recognition unavailable',
+              description:
+                'Azure speech service could not be started. Recording will continue without live transcription.',
+              variant: 'destructive',
+            });
+          }
+        } else {
           toast({
             title: 'Speech recognition unavailable',
             description:


### PR DESCRIPTION
## Summary
- Safely return `null` when Azure speech credentials are absent
- Gracefully skip speech recognition and show toast when credentials are missing or service fails to start

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a335d699ac832fa7626fb1d5269cb2